### PR TITLE
Rework CI to be granular

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
           - arm32v6
           - arm32v7
           - arm64v8
-          - i386
           - ppc64le
           - s390x
     runs-on: ubuntu-latest
@@ -70,7 +69,6 @@ jobs:
           - arm32v6
           - arm32v7
           - arm64v8
-          - i386
           - ppc64le
           - s390x
     runs-on: ubuntu-latest
@@ -159,7 +157,6 @@ jobs:
                           linux-arm32v6 \
                           linux-arm32v7 \
                           linux-arm64v8 \
-                          linux-i386 \
                           linux-ppc64le \
                           linux-s390x
           do
@@ -181,7 +178,6 @@ jobs:
                       ${{ steps.version.outputs.group1 }}-linux-arm32v6
                       ${{ steps.version.outputs.group1 }}-linux-arm32v7
                       ${{ steps.version.outputs.group1 }}-linux-arm64v8
-                      ${{ steps.version.outputs.group1 }}-linux-i386
                       ${{ steps.version.outputs.group1 }}-linux-ppc64le
                       ${{ steps.version.outputs.group1 }}-linux-s390x'
         if: ${{ steps.skip.outputs.no == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: ["master"]
-    tags: ["*"]
+    tags: ["v*"]
   pull_request:
     branches: ["master"]
   schedule:
@@ -14,7 +14,79 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  ############
+  # Building #
+  ############
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ["amd64", "arm32v6", "arm32v7", "arm64v8", "ppc64le", "s390x"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@v2
+
+      - run: make docker.image no-cache=yes
+                  platform=linux/${{ matrix.arch }}
+                  tag=build-linux-${{ matrix.arch }}-${{ github.run_number }}
+
+      - run: make docker.tar
+                  to-file=.cache/image-linux-${{ matrix.arch }}.tar
+                  tags=build-linux-${{ matrix.arch }}-${{ github.run_number }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: linux-${{ matrix.arch }}-${{ github.run_number }}
+          path: .cache/image-linux-${{ matrix.arch }}.tar
+          retention-days: 1
+
+
+
+
+  ###########
+  # Testing #
+  ###########
+
+  test:
+    needs: ["build"]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ["amd64", "arm32v6", "arm32v7", "arm64v8", "ppc64le", "s390x"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: make npm.install
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: linux-${{ matrix.arch }}-${{ github.run_number }}
+          path: .cache/
+      - run: make docker.untar
+                  from-file=.cache/image-linux-${{ matrix.arch }}.tar
+
+      - run: make test.docker
+                  platforms=linux/${{ matrix.arch }}
+                  tag=build-linux-${{ matrix.arch }}-${{ github.run_number }}
+
+
+
+
+
+
+
+
+
+
+
+
+
   buildx:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
 
       - run: make docker.image no-cache=yes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,26 +23,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ["amd64", "arm32v6", "arm32v7", "arm64v8", "ppc64le", "s390x"]
+        os: ["linux"]
+        arch:
+          - amd64
+          - arm32v6
+          - arm32v7
+          - arm64v8
+          - i386
+          - ppc64le
+          - s390x
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 0  # for correct image labeling via `git describe --tags`
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
 
       - run: make docker.image no-cache=yes
-                  platform=linux/${{ matrix.arch }}
-                  tag=build-linux-${{ matrix.arch }}-${{ github.run_number }}
+                  platform=${{ matrix.os }}/${{ matrix.arch }}
+                  tag=build-${{ github.run_number }}-${{ matrix.os }}-${{ matrix.arch }}
 
-      - run: make docker.tar
-                  to-file=.cache/image-linux-${{ matrix.arch }}.tar
-                  tags=build-linux-${{ matrix.arch }}-${{ github.run_number }}
+      - run: make docker.tar to-file=.cache/image.tar
+                  tags=build-${{ github.run_number }}-${{ matrix.os }}-${{ matrix.arch }}
       - uses: actions/upload-artifact@v3
         with:
-          name: linux-${{ matrix.arch }}-${{ github.run_number }}
-          path: .cache/image-linux-${{ matrix.arch }}.tar
+          name: ${{ matrix.os }}-${{ matrix.arch }}-${{ github.run_number }}
+          path: .cache/image.tar
           retention-days: 1
 
 
@@ -57,128 +64,175 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ["amd64", "arm32v6", "arm32v7", "arm64v8", "ppc64le", "s390x"]
+        os: ["linux"]
+        arch:
+          - amd64
+          - arm32v6
+          - arm32v7
+          - arm64v8
+          - i386
+          - ppc64le
+          - s390x
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
       - run: make npm.install
 
       - uses: actions/download-artifact@v3
         with:
-          name: linux-${{ matrix.arch }}-${{ github.run_number }}
+          name: ${{ matrix.os }}-${{ matrix.arch }}-${{ github.run_number }}
           path: .cache/
-      - run: make docker.untar
-                  from-file=.cache/image-linux-${{ matrix.arch }}.tar
+      - run: make docker.untar from-file=.cache/image.tar
 
       - run: make test.docker
-                  platforms=linux/${{ matrix.arch }}
-                  tag=build-linux-${{ matrix.arch }}-${{ github.run_number }}
+                  platform=${{ matrix.os }}/${{ matrix.arch }}
+                  tag=build-${{ github.run_number }}-${{ matrix.os }}-${{ matrix.arch }}
 
 
 
 
+  #############
+  # Releasing #
+  #############
 
+  push:
+    if: ${{ github.event_name == 'push'
+         && startsWith(github.ref, 'refs/tags/') }}
+    needs: ["build", "test"]
+    strategy:
+      fail-fast: false
+      matrix:
+        registry: ["docker.io", "ghcr.io", "quay.io"]
+    runs-on: ubuntu-latest
+    steps:
+      # Skip if this is fork and no credentials are provided.
+      - id: skip
+        run: echo "no=${{ !(
+               github.repository_owner != 'instrumentisto'
+               && ((matrix.registry == 'quay.io'
+                    && secrets.QUAYIO_ROBOT_USER == '')
+                || (matrix.registry == 'docker.io'
+                    && secrets.DOCKERHUB_BOT_USER == ''))
+             ) }}" >> $GITHUB_OUTPUT
 
+      - uses: actions/checkout@v3
+        if: ${{ steps.skip.outputs.no == 'true' }}
 
+      - name: Parse Docker image name from Git repository name
+        id: image
+        uses: actions-ecosystem/action-regex-match@v2
+        with:
+          text: ${{ github.repository }}
+          regex: '^${{ github.repository_owner }}/(.+)-docker-image$'
+      - name: Parse version from Git tag
+        id: version
+        uses: actions-ecosystem/action-regex-match@v2
+        with:
+          text: ${{ github.ref }}
+          regex: '^refs/tags/v(.+)$'
 
+      - uses: actions/download-artifact@v3
+        with:
+          path: .cache/
+        if: ${{ steps.skip.outputs.no == 'true' }}
 
+      - name: Login to ${{ matrix.registry }} container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ matrix.registry }}
+          username: ${{ (matrix.registry == 'docker.io'
+                         && secrets.DOCKERHUB_BOT_USER)
+                     || (matrix.registry == 'quay.io'
+                         && secrets.QUAYIO_ROBOT_USER)
+                     || github.repository_owner }}
+          password: ${{ (matrix.registry == 'docker.io'
+                         && secrets.DOCKERHUB_BOT_PASS)
+                     || (matrix.registry == 'quay.io'
+                         && secrets.QUAYIO_ROBOT_TOKEN)
+                     || secrets.GITHUB_TOKEN }}
+        if: ${{ steps.skip.outputs.no == 'true' }}
 
+      - name: Tag and push single-platform images
+        run: |
+          for platform in linux-amd64 \
+                          linux-arm32v6 \
+                          linux-arm32v7 \
+                          linux-arm64v8 \
+                          linux-i386 \
+                          linux-ppc64le \
+                          linux-s390x
+          do
+            make docker.untar \
+                 from-file=.cache/$platform-${{ github.run_number }}/image.tar
+            make docker.tags \
+                 of=build-${{ github.run_number }}-$platform \
+                 tags=${{ steps.version.outputs.group1 }}-$platform \
+                 registries=${{ matrix.registry }}
+            make docker.push \
+                 tags=${{ steps.version.outputs.group1 }}-$platform \
+                 registries=${{ matrix.registry }}
+          done
+        if: ${{ steps.skip.outputs.no == 'true' }}
+      - name: Tag and push multi-platform images
+        run: make docker.manifest push=yes
+                  registries=${{ matrix.registry }}
+                  of='${{ steps.version.outputs.group1 }}-linux-amd64
+                      ${{ steps.version.outputs.group1 }}-linux-arm32v6
+                      ${{ steps.version.outputs.group1 }}-linux-arm32v7
+                      ${{ steps.version.outputs.group1 }}-linux-arm64v8
+                      ${{ steps.version.outputs.group1 }}-linux-i386
+                      ${{ steps.version.outputs.group1 }}-linux-ppc64le
+                      ${{ steps.version.outputs.group1 }}-linux-s390x'
+        if: ${{ steps.skip.outputs.no == 'true' }}
 
+      # On GitHub Container Registry README is automatically updated on pushes.
+      - name: Update README on Docker Hub
+        uses: christian-korneck/update-container-description-action@v1
+        with:
+          provider: dockerhub
+          destination_container_repo: ${{ github.repository_owner }}/${{ steps.image.outputs.group1 }}
+          readme_file: README.md
+        env:
+          DOCKER_USER: ${{ secrets.DOCKERHUB_BOT_USER }}
+          DOCKER_PASS: ${{ secrets.DOCKERHUB_BOT_PASS }}
+        if: ${{ steps.skip.outputs.no == 'true'
+             && matrix.registry == 'docker.io' }}
+      - name: Update README on Quay.io
+        uses: christian-korneck/update-container-description-action@v1
+        with:
+          provider: quay
+          destination_container_repo: ${{ matrix.registry }}/${{ github.repository_owner }}/${{ steps.image.outputs.group1 }}
+          readme_file: README.md
+        env:
+          DOCKER_APIKEY: ${{ secrets.QUAYIO_API_TOKEN }}
+        if: ${{ steps.skip.outputs.no == 'true'
+             && matrix.registry == 'quay.io' }}
 
-
-  buildx:
-    if: ${{ false }}
+  release-github:
+    name: release (GitHub)
+    if: ${{ github.event_name == 'push'
+         && startsWith(github.ref, 'refs/tags/') }}
+    needs: ["push"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Parse version from Git tag
+        id: version
+        uses: actions-ecosystem/action-regex-match@v2
         with:
-          fetch-depth: 0
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+          text: ${{ github.ref }}
+          regex: '^refs/tags/v(.+)$'
 
-      - name: Pre-build fresh Docker images cache
-        run: make docker.build.cache no-cache=yes
-
-      - name: Test Docker images
-        run: |
-          # Enable experimental features of Docker Daemon to run multi-arch
-          # images.
-          echo "$(cat /etc/docker/daemon.json)" '{"experimental": true}' \
-          | jq --slurp 'reduce .[] as $item ({}; . * $item)' \
-          | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-
-          make npm.install
-          make test.docker platforms=@all build=yes
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ github.event_name == 'push'
-                && startsWith(github.ref, 'refs/tags/v') }}
-      - name: Login to Quay.io
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: instrumentisto+bot
-          password: ${{ secrets.QUAYIO_ROBOT_TOKEN }}
-        if: ${{ github.event_name == 'push'
-                && startsWith(github.ref, 'refs/tags/v') }}
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: instrumentistobot
-          password: ${{ secrets.DOCKERHUB_BOT_PASS }}
-        if: ${{ github.event_name == 'push'
-                && startsWith(github.ref, 'refs/tags/v') }}
-
-      - run: make docker.push
-        if: ${{ github.event_name == 'push'
-                && startsWith(github.ref, 'refs/tags/v') }}
-
-      # On GitHub Container Registry README is automatically updated on pushes.
-      - name: Update README on Quay.io
-        uses: christian-korneck/update-container-description-action@v1
-        env:
-          DOCKER_APIKEY: ${{ secrets.QUAYIO_API_TOKEN }}
-        with:
-          provider: quay
-          destination_container_repo: quay.io/instrumentisto/haraka
-          readme_file: README.md
-        if: ${{ github.event_name == 'push'
-                && startsWith(github.ref, 'refs/tags/v') }}
-      - name: Update README on Docker Hub
-        uses: christian-korneck/update-container-description-action@v1
-        env:
-          DOCKER_USER: instrumentistobot
-          DOCKER_PASS: ${{ secrets.DOCKERHUB_BOT_PASS }}
-        with:
-          provider: dockerhub
-          destination_container_repo: instrumentisto/haraka
-          readme_file: README.md
-        if: ${{ github.event_name == 'push'
-                && startsWith(github.ref, 'refs/tags/v') }}
-
-      - name: Parse release version from Git tag
-        id: release
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
-        if: ${{ github.event_name == 'push'
-                && startsWith(github.ref, 'refs/tags/v') }}
       - name: Parse CHANGELOG link
         id: changelog
-        run: echo ::set-output name=LINK::https://github.com/${{ github.repository }}/blob/v${{ steps.release.outputs.VERSION }}/CHANGELOG.md#$(sed -n '/^## \[${{ steps.release.outputs.VERSION }}\]/{s/^## \[\(.*\)\][^0-9]*\([0-9].*\)/\1--\2/;s/[^0-9a-z-]*//g;p;}' CHANGELOG.md)
-        if: ${{ github.event_name == 'push'
-                && startsWith(github.ref, 'refs/tags/v') }}
-      - name: Release on GitHub
+        run: echo "link=${{ github.server_url }}/${{ github.repository }}/blob/v${{ steps.version.outputs.group1 }}/CHANGELOG.md#$(sed -n '/^## \[${{ steps.version.outputs.group1 }}\]/{s/^## \[\(.*\)\][^0-9]*\([0-9].*\)/\1--\2/;s/[^0-9a-z-]*//g;p;}' CHANGELOG.md)"
+             >> $GITHUB_OUTPUT
+
+      - name: Create GitHub release
         uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: ${{ steps.release.outputs.VERSION }}
+          name: ${{ steps.version.outputs.group1 }}
           body: |
-            [Changelog](${{ steps.changelog.outputs.LINK }})
-        if: ${{ github.event_name == 'push'
-                && startsWith(github.ref, 'refs/tags/v') }}
+            [Changelog](${{ steps.changelog.outputs.link }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,7 +278,6 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
-
 [Alpine Linux]: https://www.alpinelinux.org
 [Haraka]: https://haraka.github.io 
 [Node.js]: https://nodejs.org

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,33 @@ docker.push:
 				--push)))
 
 
+# Save Docker images to a tarball file.
+#
+# Usage:
+#	make docker.tar [to-file=(.cache/image.tar|<file-path>)]
+#	                [tags=($(VERSION)|<docker-tag-1>[,<docker-tag-2>...])]
+
+docker-tar-file = $(or $(to-file),.cache/image.tar)
+
+docker.tar:
+	@mkdir -p $(dir $(docker-tar-file))
+	docker save -o $(docker-tar-file) \
+		$(foreach tag,$(subst $(comma), ,$(or $(tags),$(VERSION))),\
+			$(OWNER)/$(NAME):$(tag))
+
+
+docker.test: test.docker
+
+
+# Load Docker images from a tarball file.
+#
+# Usage:
+#	make docker.untar [from-file=(.cache/image.tar|<file-path>)]
+
+docker.untar:
+	docker load -i $(or $(from-file),.cache/image.tar)
+
+
 
 
 ####################
@@ -260,7 +287,8 @@ endif
 ##################
 
 .PHONY: image push release test \
-        docker.build.cache docker.image docker.push \
+        docker.build.cache docker.image docker.push docker.tar docker.test \
+        docker.untar\
         git.release \
         npm.install \
         test.docker

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ eq = $(if $(or $(1),$(2)),$(and $(findstring $(1),$(2)),\
 dockerify = $(strip $(if $(call eq,$(1),linux/arm32v6),linux/arm/v6,\
                     $(if $(call eq,$(1),linux/arm32v7),linux/arm/v7,\
                     $(if $(call eq,$(1),linux/arm64v8),linux/arm64/v8,\
-                    $(if $(call eq,$(1),linux/i386),   linux/386,\
-                                                       $(platform))))))
+                                                       $(platform)))))
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,11 @@ define docker.buildx
 	$(eval github_repo := $(strip $(or $(GITHUB_REPOSITORY),\
 	                                   instrumentisto/haraka-docker-image)))
 	docker buildx build --force-rm $(args) \
-		--platform $(platform) \
+		--platform $(strip \
+			$(if $(call eq,$(platform),linux/arm32v6),linux/arm/v6,\
+			$(if $(call eq,$(platform),linux/arm32v7),linux/arm/v7,\
+			$(if $(call eq,$(platform),linux/arm64v8),linux/arm64,\
+			                                          $(platform))))) \
 		$(if $(call eq,$(no-cache),yes),--no-cache --pull,) \
 		--build-arg haraka_ver=$(HARAKA_VER) \
 		--build-arg node_ver=$(NODE_VER) \

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ docker.tar:
 	@mkdir -p $(dir $(docker-tar-file))
 	docker save -o $(docker-tar-file) \
 		$(foreach tag,$(subst $(comma), ,$(or $(tags),$(VERSION))),\
-			$(OWNER)/$(NAME):$(tag))
+			instrumentisto/$(NAME):$(tag))
 
 
 docker.test: test.docker

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Haraka Docker image
 
 ## Supported platforms
 
-- `linux`: `amd64`, `arm32v6`, `arm32v7`, `arm64v8`, `i386`, `ppc64le`, `s390x`
+- `linux`: `amd64`, `arm32v6`, `arm32v7`, `arm64v8`, `ppc64le`, `s390x`
 
 
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Haraka Docker image
 
 
 
+## Supported platforms
+
+- `linux`: `amd64`, `arm32v6`, `arm32v7`, `arm64v8`, `i386`, `ppc64le`, `s390x`
+
+
+
+
 ## What is Haraka?
 
 [Haraka] is an open source [SMTP] server written in [Node.js] which provides extremely high performance coupled with a flexible plugin system allowing [Javascript] programmers full access to change the behaviour of the server.
@@ -91,31 +98,48 @@ docker run -d -p 25:25 \
 
 ## Image tags
 
-This image is based on the popular [Alpine Linux project][11], available in [the alpine official image][12]. Alpine Linux is much smaller than most distribution base images (~5MB), and thus leads to much slimmer images in general.
+This image is based on the popular [Alpine Linux project][11], available in [the alpine official image][12]. [Alpine Linux][11] is much smaller than most distribution base images (~5MB), and thus leads to much slimmer images in general.
 
-This variant is highly recommended when final image size being as small as possible is desired. The main caveat to note is that it does use [musl libc][13] instead of [glibc and friends][14], so certain software might run into issues depending on the depth of their libc requirements. However, most software doesn't have an issue with this, so this variant is usually a very safe choice. See [this Hacker News comment thread][15] for more discussion of the issues that might arise and some pro/con comparisons of using Alpine-based images.
-
-
-### `X`
-
-Latest tag of `X` [Haraka]'s major version.
+This variant is highly recommended when final image size being as small as possible is desired. The main caveat to note is that it does use [musl libc][13] instead of [glibc and friends][14], so certain software might run into issues depending on the depth of their libc requirements. However, most software doesn't have an issue with this, so this variant is usually a very safe choice. See [this Hacker News comment thread][15] for more discussion of the issues that might arise and some pro/con comparisons of using [Alpine][11]-based images.
 
 
-### `X.Y`
+### `<X>`
 
-Latest tag of `X.Y` [Haraka]'s minor version.
+Latest tag of the latest major `X` [Haraka] version.
 
-
-### `X.Y.Z`
-
-Latest tag version of a concrete `X.Y.Z` version of [Haraka].
+This is a multi-platform image.
 
 
-### `X.Y.Z-nodeA-rN`
+### `<X.Y>`
 
-Concrete `N` image revision tag of a [Haraka]'s concrete `X.Y.Z` version installed with `A` major version of [Node.js].
+Latest tag of the latest minor `X.Y` [Haraka] version.
 
-Once build, it's never updated.
+This is a multi-platform image.
+
+
+### `<X.Y.Z>`
+
+Latest tag of the concrete `X.Y.Z` [Haraka] version.
+
+This is a multi-platform image.
+
+
+### `<X.Y.Z>-node<A>-r<N>`
+
+Concrete `N` image revision tag of the concrete `X.Y.Z` [Haraka] version installed with `A` major version of [Node.js].
+
+Once built, it's never updated.
+
+This is a multi-platform image.
+
+
+### `<X.Y.Z>-node<A>-r<N>-<os>-<arch>`
+
+Concrete `N` image revision tag of the concrete `X.Y.Z` [Haraka] version installed with `A` major version of [Node.js] on the concrete `os` and `arch`.
+
+Once built, it's never updated.
+
+This is a single-platform image.
 
 
 
@@ -138,7 +162,6 @@ The [sources][92] for producing `instrumentisto/haraka` Docker images are licens
 We can't notice comments in the [DockerHub] (or other container registries) so don't use them for reporting issue or asking question.
 
 If you have any problems with or questions about this image, please contact us through a [GitHub issue][101].
-
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "bats": "^1.2"
+    "bats": "^1.8"
   }
 }

--- a/tests/main.bats
+++ b/tests/main.bats
@@ -2,17 +2,20 @@
 
 
 @test "Built on correct arch" {
-  run docker run --rm --platform $PLATFORM --entrypoint sh $IMAGE -c \
+  run docker run --rm --pull never --platform $PLATFORM \
+                 --entrypoint sh $IMAGE -c \
     'uname -m'
   [ "$status" -eq 0 ]
   if [ "$PLATFORM" = "linux/amd64" ]; then
     [ "$output" = "x86_64" ]
-  elif [ "$PLATFORM" = "linux/arm64v8" ]; then
+  elif [ "$PLATFORM" = "linux/arm/v6" ]; then
+    [ "$output" = "armv7l" ]
+  elif [ "$PLATFORM" = "linux/arm/v7" ]; then
+    [ "$output" = "armv7l" ]
+  elif [ "$PLATFORM" = "linux/arm64/v8" ]; then
     [ "$output" = "aarch64" ]
-  elif [ "$PLATFORM" = "linux/arm32v6" ]; then
-    [ "$output" = "armv7l" ]
-  elif [ "$PLATFORM" = "linux/arm32v7" ]; then
-    [ "$output" = "armv7l" ]
+  elif [ "$PLATFORM" = "linux/386" ]; then
+    [ "$output" = "x86_64" ]
   else
     [ "$output" = "$(echo $PLATFORM | cut -d '/' -f2-)" ]
   fi
@@ -20,13 +23,15 @@
 
 
 @test "Haraka is installed" {
-  run docker run --rm --platform $PLATFORM --entrypoint sh $IMAGE -c \
+  run docker run --rm --pull never --platform $PLATFORM \
+                 --entrypoint sh $IMAGE -c \
     'which haraka'
   [ "$status" -eq 0 ]
 }
 
 @test "Haraka runs ok" {
-  run docker run --rm --platform $PLATFORM --entrypoint sh $IMAGE -c \
+  run docker run --rm --pull never --platform $PLATFORM \
+                      --entrypoint sh $IMAGE -c \
     'haraka -o -c /etc/haraka'
   [ "$status" -eq 0 ]
 }
@@ -37,7 +42,8 @@
   [ ! "$output" = '' ]
   expected="$output"
 
-  run docker run --rm --platform $PLATFORM --entrypoint sh $IMAGE -c \
+  run docker run --rm --pull never --platform $PLATFORM \
+                 --entrypoint sh $IMAGE -c \
     "haraka --version | grep 'Version: ' | cut -d ':' -f2 | tr -d ' '"
   [ "$status" -eq 0 ]
   [ ! "$output" = '' ]
@@ -48,7 +54,7 @@
 
 
 @test "APK_INSTALL_PACKAGES installs packages" {
-  run docker run --rm --platform $PLATFORM \
+  run docker run --rm --pull never --platform $PLATFORM \
                  -e APK_INSTALL_PACKAGES=openssl,rclone \
              $IMAGE apk list
   [ "$status" -eq 0 ]

--- a/tests/main.bats
+++ b/tests/main.bats
@@ -7,11 +7,11 @@
   [ "$status" -eq 0 ]
   if [ "$PLATFORM" = "linux/amd64" ]; then
     [ "$output" = "x86_64" ]
-  elif [ "$PLATFORM" = "linux/arm64" ]; then
+  elif [ "$PLATFORM" = "linux/arm64v8" ]; then
     [ "$output" = "aarch64" ]
-  elif [ "$PLATFORM" = "linux/arm/v6" ]; then
+  elif [ "$PLATFORM" = "linux/arm32v6" ]; then
     [ "$output" = "armv7l" ]
-  elif [ "$PLATFORM" = "linux/arm/v7" ]; then
+  elif [ "$PLATFORM" = "linux/arm32v7" ]; then
     [ "$output" = "armv7l" ]
   else
     [ "$output" = "$(echo $PLATFORM | cut -d '/' -f2-)" ]

--- a/tests/main.bats
+++ b/tests/main.bats
@@ -14,8 +14,6 @@
     [ "$output" = "armv7l" ]
   elif [ "$PLATFORM" = "linux/arm64/v8" ]; then
     [ "$output" = "aarch64" ]
-  elif [ "$PLATFORM" = "linux/386" ]; then
-    [ "$output" = "x86_64" ]
   else
     [ "$output" = "$(echo $PLATFORM | cut -d '/' -f2-)" ]
   fi


### PR DESCRIPTION
This is a third attempt to make CI pipeline for building multi-arch images granular, as it already is for single-arch image repos.